### PR TITLE
chore: prevent normalization of semver versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ with io.open(readme_filename, encoding="utf-8") as readme_file:
 setuptools.setup(
     name="google-cloud-bigquery-reservation",
     description="Google Cloud BigQuery Reservation API client library",
-    version=version,
+    version=setuptools.sic(version),
     release_status="Development Status :: 4 - Beta",
     long_description=readme,
     author="Google LLC",


### PR DESCRIPTION
When there is a patch version added to semver versioning, setuptools.setup(version) will normalize the versioning from `-patch` to `.patch` which is not correct SEMVER versioning. The added feature with setuptools.sic(version) will prevent this from happening.