### PR TITLE
chore: use workaround for sic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,21 @@ import io
 import os
 import setuptools  # type: ignore
 
+# Disable version normalization performed by setuptools.setup()
+try:
+    # Try the approach of using sic(), added in setuptools 46.1.0
+    from setuptools import sic
+except ImportError:
+    # Try the approach of replacing packaging.version.Version
+    sic = lambda v: v
+    try:
+        # setuptools >=39.0.0 uses packaging from setuptools.extern
+        from setuptools.extern import packaging
+    except ImportError:
+        # setuptools <39.0.0 uses packaging from pkg_resources.extern
+        from pkg_resources.extern import packaging
+    packaging.version.Version = packaging.version.LegacyVersion
+
 version = "1.1.0"
 
 package_root = os.path.abspath(os.path.dirname(__file__))
@@ -30,7 +45,7 @@ with io.open(readme_filename, encoding="utf-8") as readme_file:
 setuptools.setup(
     name="google-cloud-bigquery-reservation",
     description="Google Cloud BigQuery Reservation API client library",
-    version=setuptools.sic(version),
+    version=sic(version),
     release_status="Development Status :: 4 - Beta",
     long_description=readme,
     author="Google LLC",


### PR DESCRIPTION
To prevent any breakages, adding workaround to the PR submitted from #91. This workaround will make sure that sic works even with incompatible setuptools version.