### PR TITLE
docs: Update the README to reflect that this library is GA

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,15 @@
 Python Client for Cloud BigQuery Reservation
 =================================================
 
-|beta| |pypi| |versions|
+|GA| |pypi| |versions|
 
 `BigQuery Reservation API`_: Modify BigQuery flat-rate reservations.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |beta| image:: https://img.shields.io/badge/support-beta-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#beta-support
+.. |GA| image:: https://img.shields.io/badge/support-ga-gold.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-reservation.svg
    :target: https://pypi.org/project/google-cloud-bigquery-reservation/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-reservation.svg

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     name="google-cloud-bigquery-reservation",
     description="Google Cloud BigQuery Reservation API client library",
     version=version,
-    release_status="Development Status :: 4 - Beta",
+    release_status="Development Status :: 5 - Production/Stable",
     long_description=readme,
     author="Google LLC",
     author_email="googleapis-packages@google.com",
@@ -47,7 +47,7 @@ setuptools.setup(
     ),
     python_requires=">=3.6",
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
[.repo-metadata.json includes GA](https://github.com/googleapis/python-bigquery-reservation/blob/master/.repo-metadata.json#L7) however the README still has beta.