### PR TITLE
chore: add Yoshi and BigQuery teams to sample approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 *               @googleapis/api-bigquery @googleapis/yoshi-python
 
 # The python-samples-reviewers team is the default owner for samples changes
-/samples/   @googleapis/python-samples-owners
+/samples/   @googleapis/python-samples-owners @googleapis/api-bigquery @googleapis/yoshi-python


### PR DESCRIPTION
This allows the BigQuery team to own our own samples. Also enables the Yoshi team to merge PRs such as those by Renovate.
