### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "bigqueryreservation",
     "name_pretty": "Google BigQuery Reservation",
     "product_documentation": "https://cloud.google.com/bigquery/docs/reference/reservations",
-    "client_documentation": "https://googleapis.dev/python/bigqueryreservation/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/bigqueryreservation/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Cloud BigQuery Reservation
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-reservation.svg
    :target: https://pypi.org/project/google-cloud-bigqyery-reservation/
 .. _BigQuery Reservation API: https://cloud.google.com/bigquery/docs/reference/reservations/rpc
-.. _Client Library Documentation: https://googleapis.dev/python/bigqueryreservation/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigqueryreservation/latest
 .. _Product Documentation: https://cloud.google.com/bigquery/docs/reservations-intro
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.